### PR TITLE
manifest/cache: don't jump to 'parent directory' anymore, path-canonicalization is done elsewhere

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -614,8 +614,7 @@ impl Responder for WharfixManifest {
 async fn manifest(registry: Registry, info: web::Path<FetchInfo>) -> Result<WharfixManifest, DockerError> {
 
     //try to look up existing manifest blob
-    let existing_blob = registry.blob(&info).await
-        .and_then(|blob_info| blob_info.path.parent().map(Path::to_path_buf).ok_or(DockerError::snafu("Failed to get parent diretory of manifest.json")));
+    let existing_blob = registry.blob(&info).await.map(|blob_info| blob_info.path);
 
     let path = match existing_blob {
         Ok(path) => Ok(path),


### PR DESCRIPTION
This was a regression introduced with #17

path-canonicalization is now done in a subroutine, so we shouldn't try to move up a directory-level before serving manifest.json. This causes us to end up in the root of `/nix/store`, i.e. `/nix/store/manifest.json` - whoops.

The reason this didn't show in my local tests of #17 is... my local docker image cache. Docker doesn't want to even try to pull: `localhost:8088/sl@sha256:05383ff1d78337b9014cae19195d1f6c2c1d0d4a2937de18893fd2f919c90941` because it recons that it already has that.

Note to self: use Curl more for testing -- or if using the docker cli, remember to system prune before the test.