### PR TITLE
Revert "manifest/cache: don't jump to 'parent directory' anymore, path-canonicalization is done elsewhere"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -614,7 +614,8 @@ impl Responder for WharfixManifest {
 async fn manifest(registry: Registry, info: web::Path<FetchInfo>) -> Result<WharfixManifest, DockerError> {
 
     //try to look up existing manifest blob
-    let existing_blob = registry.blob(&info).await.map(|blob_info| blob_info.path);
+    let existing_blob = registry.blob(&info).await
+        .and_then(|blob_info| blob_info.path.parent().map(Path::to_path_buf).ok_or(DockerError::snafu("Failed to get parent diretory of manifest.json")));
 
     let path = match existing_blob {
         Ok(path) => Ok(path),


### PR DESCRIPTION
Reverts wharfix/wharfix#18

#18 has to be reverted, because I was stupid.

We after all _need_ to traverse to "parent directory", because since #11 we are now caching the manifest-file as blob, and the confusing part is that `parent()` here just means "dirname", i.e. we need the dirname of the resolved cache-path like:  `/nix/store/ihzwrk2k6w63yx6x8s75njv8cf6r7l5y-toolbox-servable/manifest.json` -> `/nix/store/ihzwrk2k6w63yx6x8s75njv8cf6r7l5y-toolbox-servable`, which we then later append `manifest.json` to in line 633.

The blob-cache dir on nix-build-p03 needed to be cleared in order to discover this mistake.