### PR TITLE
git2: pin to 0.13.21 until rust-lang/git2-rs#746 is fixed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,9 +976,9 @@ checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "git2"
-version = "0.13.22"
+version = "0.13.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1cbbfc9a1996c6af82c2b4caf828d2c653af4fcdbb0e5674cc966eee5a4197"
+checksum = "659cd14835e75b64d9dba5b660463506763cf0aa6cb640aeeb0e98d841093490"
 dependencies = [
  "bitflags",
  "libc",
@@ -1204,9 +1204,9 @@ checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.23+1.2.0"
+version = "0.12.22+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29730a445bae719db3107078b46808cc45a5b7a6bae3f31272923af969453356"
+checksum = "89c53ac117c44f7042ad8d8f5681378dfbc6010e49ec2c0d1f11dfedc7a4a1c3"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -2794,9 +2794,9 @@ rec {
       };
       "git2" = rec {
         crateName = "git2";
-        version = "0.13.22";
+        version = "0.13.21";
         edition = "2018";
-        sha256 = "15s1bbp6x5ncfib0xfyd9ypm7inj53wcmd62hapwd5hrkbybn74w";
+        sha256 = "141l150xi60fxfp41dkcmbq3qxh66m361dm5vgcn8nz76m4d3735";
         authors = [
           "Josh Triplett <josh@joshtriplett.org>"
           "Alex Crichton <alex@alexcrichton.com>"
@@ -2840,7 +2840,6 @@ rec {
           "https" = [ "libgit2-sys/https" "openssl-sys" "openssl-probe" ];
           "ssh" = [ "libgit2-sys/ssh" ];
           "ssh_key_from_memory" = [ "libgit2-sys/ssh_key_from_memory" ];
-          "vendored-libgit2" = [ "libgit2-sys/vendored" ];
           "vendored-openssl" = [ "openssl-sys/vendored" "libgit2-sys/vendored-openssl" ];
           "zlib-ng-compat" = [ "libgit2-sys/zlib-ng-compat" ];
         };
@@ -3408,9 +3407,9 @@ rec {
       };
       "libgit2-sys" = rec {
         crateName = "libgit2-sys";
-        version = "0.12.23+1.2.0";
+        version = "0.12.22+1.1.0";
         edition = "2018";
-        sha256 = "0mik8mlzjfljf89g7qxslsvsaifc11lb8y3h22rrswdfbd20lwr9";
+        sha256 = "1hx1lk3yvpqi3w6jrv291q0wdywd6y0md3wdmm170ky42z0kmic9";
         libName = "libgit2_sys";
         libPath = "lib.rs";
         authors = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ uuid = { version = "0.8", features = ["v4"] }
 lazy_static = "1.4"
 linereader = "0.4.0"
 walkdir = "2.3"
-git2 = "0.13"
+git2 = "=0.13.21"
 tempdir = "0.3"
 tempfile = "3.1"
 regex = "1.3"


### PR DESCRIPTION
wharfix fails on repo clone with `invalid version 0 on git_proxy_options`. As a temporary solution, let's downgrade git2 and pin it, until the issue is (hopefully) resolved.

ref rust-lang/git2-rs#746