### PR TITLE
2021 rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,6 @@ dependencies = [
  "regex",
  "rust-crypto",
  "serde",
- "serde_derive",
  "serde_json",
  "tempdir",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,11 @@
 name = "wharfix"
 version = "0.1.0"
 authors = ["Johan Thomsen <jth@dbc.dk>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 clap = "2"
-serde = "1"
-serde_derive = "1"
+serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 erased-serde = "0"
 actix-web = "2"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,7 @@ use crate::exec::ExecErrorInfo;
 use crate::FetchInfo;
 
 use serde::Serialize;
+use serde_json::json;
 
 use crate::log;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,3 @@
-extern crate actix_web;
-extern crate clap;
-#[macro_use] extern crate serde_derive;
-#[macro_use] extern crate serde_json;
-#[macro_use] extern crate lazy_static;
-#[macro_use] extern crate mysql;
-extern crate tokio;
-extern crate uuid;
-extern crate linereader;
-extern crate tempdir;
-extern crate regex;
 
 use actix_web::http::StatusCode;
 use std::collections::HashMap;
@@ -16,8 +5,7 @@ use std::string::String;
 
 use actix_web::{App, HttpServer, middleware, Responder, web, FromRequest, HttpRequest, HttpResponse, Error};
 
-use crate::actix_web::dev::Service;
-use actix_web::dev::{HttpResponseBuilder};
+use actix_web::dev::{HttpResponseBuilder, Service};
 use std::path::{Path, PathBuf};
 use std::fs;
 use walkdir::WalkDir;
@@ -45,12 +33,17 @@ use futures::future::{ok, err, Ready};
 
 use regex::Regex;
 use mysql::Pool;
-use crate::mysql::prelude::Queryable;
 
 use tempfile::NamedTempFile;
 use std::ffi::OsStr;
 
 use dbc_rust_modules::{exec, log};
+
+use serde::Deserialize;
+use lazy_static::lazy_static;
+use serde_json::json;
+use mysql::params;
+use mysql::prelude::Queryable;
 
 mod errors;
 


### PR DESCRIPTION
get rid of 'extern crate' and 'macro use' and add standard imports of macros instead

note: based on #56 ... Merge whichever first, but this PR currently has target branch of the former.