### PR TITLE
22.11 compat (bumps, crane, ...)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,6 @@
 {
   "nodes": {
-    "cargo2nix": {
+    "crane": {
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
@@ -10,16 +10,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1655189312,
-        "narHash": "sha256-gpJ57OgIebUpO+7F00VltxSEy6dz2x6HeJ5BcRM8rDA=",
-        "owner": "cargo2nix",
-        "repo": "cargo2nix",
-        "rev": "c149357cc3d17f2849c73eb7a09d07a307cdcfe8",
+        "lastModified": 1669605882,
+        "narHash": "sha256-TiQtL5sUI5rp28S63v+VX25qNjcrc8Xeu+shf3g7Tj4=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "24591d5f8cc979f7b243b88a2d39da09976970ad",
         "type": "github"
       },
       "original": {
-        "owner": "cargo2nix",
-        "repo": "cargo2nix",
+        "owner": "ipetkov",
+        "repo": "crane",
         "type": "github"
       }
     },
@@ -41,11 +41,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -72,27 +72,27 @@
     },
     "root": {
       "inputs": {
-        "cargo2nix": "cargo2nix",
+        "crane": "crane",
         "nixpkgs": "nixpkgs"
       }
     },
     "rust-overlay": {
       "inputs": {
         "flake-utils": [
-          "cargo2nix",
+          "crane",
           "flake-utils"
         ],
         "nixpkgs": [
-          "cargo2nix",
+          "crane",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1653878966,
-        "narHash": "sha256-T51Gck/vrJZi1m+uTbhEFTRgZmE59sydVONadADv358=",
+        "lastModified": 1667487142,
+        "narHash": "sha256-bVuzLs1ZVggJAbJmEDVO9G6p8BH3HRaolK70KXvnWnU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8526d618af012a923ca116be9603e818b502a8db",
+        "rev": "cf668f737ac986c0a89e83b6b2e3c5ddbd8cf33b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -56,16 +56,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663494212,
-        "narHash": "sha256-gUJir35fXQB7jQKCTffM8str9N6N2soaOL0TqQfJod4=",
+        "lastModified": 1669465383,
+        "narHash": "sha256-fVbG427suESAEb8/P47O/zD/G9BSeFxLh94IUzgOchs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b47d4447dc2ba34f793436e6631fbdd56b12934a",
+        "rev": "899e7caf59d1954882a8e2dff45ccc0387c186f6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     crane.url = "github:ipetkov/crane";
     crane.inputs.nixpkgs.follows = "nixpkgs";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
   };
 
   outputs = { self, crane, nixpkgs }:

--- a/flake.nix
+++ b/flake.nix
@@ -2,23 +2,30 @@
   description = "wharfix";
 
   inputs = {
-    cargo2nix.url = "github:cargo2nix/cargo2nix";
-    cargo2nix.inputs.nixpkgs.follows = "nixpkgs";
+    crane.url = "github:ipetkov/crane";
+    crane.inputs.nixpkgs.follows = "nixpkgs";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
   };
 
-  outputs = { self, cargo2nix, nixpkgs }:
+  outputs = { self, crane, nixpkgs }:
   let
     pname = "wharfix";
     system = "x86_64-linux";
+    crane-overlay = final: prev: {
+      # crane's lib is not exposed as an overlay in its flake (should be added
+      # upstream ideally) so this interface might be brittle, but avoids
+      # accidentally passing a detached nixpkgs from its flake (or its follows)
+      # on to consumers.
+      craneLib = crane.mkLib prev;
+    };
     pkgs = import nixpkgs {
       inherit system;
-      overlays = [ self.overlay cargo2nix.overlays.default ];
+      overlays = [ self.overlay crane-overlay ];
     };
     lib = nixpkgs.lib;
 
     outputPackages = {
-      "${pname}" = ["default"];
+      "${pname}" = [];
       "${pname}-mysql" = ["mysql"];
     };
   in {
@@ -28,24 +35,34 @@
     overlay = final: prev:
     let
       cratePackage = name: features:
-        (final.rustBuilder.makePackageSet {
-          rustVersion = final.rustc.version;
-          packageFun = import ./Cargo.nix;
-          rootFeatures = map (f: "${pname}/${f}") features;
-        }).workspace.${pname} {};
+        (final.craneLib.buildPackage {
+          src = with final; lib.cleanSourceWith {
+            src = ./.;
+            filter = let
+              # Default cleaner nukes everything but rust/cargo relevant files,
+              # and we need this in the source tree to embed it.
+              drvnix = path: _type: builtins.match ".*/drv.nix" path != null;
+            in
+              path: type: craneLib.filterCargoSources path type || drvnix path type;
+          };
+          nativeBuildInputs = with final; [
+            pkg-config
+          ];
+          buildInputs = with final; [
+            openssl
+          ];
+          cargoExtraArgs = final.lib.concatMapStringsSep " " (f: "--features=${f}") features;
+        });
     in
       lib.mapAttrs cratePackage outputPackages;
 
     devShell.${system} = with pkgs; mkShell {
-      buildInputs = [
+      inputsFrom = [ self.defaultPackage.${system} ];
+      nativeBuildInputs = [
         cargo
-        cargo2nix.packages.${system}.cargo2nix
-        nix
-        openssl.dev
-        pkgconfig
         rustc
+        nix
         rustfmt
-        zlib.dev
       ];
     };
   };


### PR DESCRIPTION
The example choo-choos correctly. crane is an almost arbitrary choice as replacement, but hopefully I've kept the outside facing API intact.

I see no dependencies upon mysql in the final binary, but there wasn't one before either, so I assume it's a pure rust library without ffi deps.