### PR TITLE
bump action: use an app-generated-token

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -15,13 +15,21 @@ jobs:
       run: |
         nix --experimental-features "nix-command flakes" flake update
         nix --experimental-features "nix-command flakes" develop --command cargo update
+
+    - name: Generate API token
+      uses: tibdex/github-app-token@v1
+      id: generate-token
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
     - name: Create pull request
       id: pr
       uses: peter-evans/create-pull-request@v5.0.2
       with:
         author: "dbcdk-platform <81445572+dbcdk-platform@users.noreply.github.com>"
         committer: "dbcdk-platform <81445572+dbcdk-platform@users.noreply.github.com>"
-        token: ${{secrets.PAT_BUMP_O_MATIC}}
+        token: ${{steps.generate-token.outputs.token}}
         commit-message: "bump-o-matic: update dependencies"
         branch: bump-o-matic
         delete-branch: true
@@ -31,7 +39,7 @@ jobs:
       uses: actions/github-script@v3
       if: ${{steps.pr.outputs.pull-request-operation != 'closed'}}
       with:
-        github-token: ${{secrets.PAT_BUMP_O_MATIC}}
+        github-token: ${{steps.generate-token.outputs.token}}
         script: |
           const res = await github.graphql(`query {
             repository(owner: "${context.repo.owner}", name: "${context.repo.repo}") {


### PR DESCRIPTION
To try and fix and get around the issues surrounding PATs as the bumper auth, use an app-generated-token as described in the action docs:

https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens