### PR TITLE
Local rev-parse fails for updated remote refs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -759,10 +759,12 @@ fn repo_checkout(repo: &Repository, reference: &String, tmp_path: &Path) -> Resu
     cb.update_index(false);
     cb.target_dir(tmp_path);
 
-    let obj = repo.revparse_single(reference.as_str()).or_else(|_| {
-        let rev = format!("refs/remotes/origin/{reference}",reference=&reference);
-        repo.revparse_single(rev.as_str()).or_else(|e| Err(RepoError::Git(e)))
-    })?;
+    let obj = {
+        let new_reference = format!("refs/remotes/origin/{reference}",reference=&reference);
+        log::info(&format!("Chaging ref: {} to: {}", &reference, &new_reference));
+        repo.revparse_single(new_reference.as_str()).or_else(|e| Err(RepoError::Git(e)))
+    }?;
+    log::info(&format!("checking out revision: {}", &obj.id()));
     repo.checkout_tree(&obj, Some(&mut cb)).or_else(|e| Err(RepoError::Git(e)))?;
     Ok(())
 }


### PR DESCRIPTION
Rev-parse of local ref (obviously) does not give expected result after git-fetch, since
only FETCH_HEAD and tracking branches are updated.

Instead of just a fallback, _always_ use /refs/remotes/origin/<ref> . Since we control the initial clone to temp, we can safely hardcode the name of the remote.

fixes #89