### PR TITLE
refactor: remove setting and getting statics unsafely with OnceLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "wharfix"
 version = "0.1.0"
 edition = "2021"
 
+# We should specify MSRV of 1.70 because we use OnceLock
+rust-version = "1.70.0"
+
 [dependencies]
 clap = "2"
 serde = { version = "1", features = [ "derive" ] }


### PR DESCRIPTION
- **refactor(gcroots): make `ADD_NIX_GCROOTS` safe**
- **refactor(indexfile): make indexfile safe**
- **refactor(servetype): make servetype safe**
- **refactor(targetdir): make targetdir safe**
- **refactor(blobcachedir): make blobcachedir safe**
- **refactor(substituters): make substituters safe**
- **refactor(sshprivatekey): make sshprivatekey safe**
