### PR TITLE
feat: idiomatic logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
  "futures-lite",
  "rustix 0.37.27",
  "signal-hook",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -931,6 +931,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,7 +966,7 @@ checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1346,6 +1359,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,7 +1440,18 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.2",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi 0.3.2",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1704,7 +1734,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2022,7 +2052,7 @@ dependencies = [
  "libc",
  "log",
  "pin-project-lite",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2030,6 +2060,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty_env_logger"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
+dependencies = [
+ "env_logger",
+ "log",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -2337,7 +2377,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2350,7 +2390,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.5",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2386,7 +2426,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2558,7 +2598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2671,7 +2711,7 @@ dependencies = [
  "fastrand 2.0.0",
  "redox_syscall",
  "rustix 0.38.11",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2771,7 +2811,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3037,7 +3077,9 @@ dependencies = [
  "git2",
  "lazy_static",
  "linereader",
+ "log",
  "mysql",
+ "pretty_env_logger",
  "regex",
  "serde",
  "serde_json",
@@ -3115,6 +3157,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ pretty_env_logger = "0.5.0"
 
 [features]
 mysql = ["dep:mysql"]
+oldlogs = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ dbc-rust-modules = { git = "https://github.com/dbcdk/rust-modules", branch = "ma
 async-process = "1"
 get_chunk = { version = "1.2.0", features = ["stream", "size_format"] }
 async-stream = "0.3.5"
+log = "0.4.20"
+pretty_env_logger = "0.5.0"
 
 [features]
 mysql = ["dep:mysql"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,6 +10,11 @@ use serde_json::json;
 
 use async_process::ExitStatus;
 
+#[cfg(not(feature = "oldlogs"))]
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+
+#[cfg(feature = "oldlogs")]
 use dbc_rust_modules::log as dbc_log;
 
 #[allow(dead_code)]
@@ -164,6 +169,9 @@ impl DockerError {
         }
     }
     pub fn unknown<E: std::fmt::Debug>(text: &str, err: E) -> Self {
+        #[cfg(not(feature = "oldlogs"))]
+        error!("{}: {:#?}", text, &err);
+        #[cfg(feature = "oldlogs")]
         dbc_log::error(text, &err);
         DockerError {
             code: DockerErrorCode::Snafu,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,22 +1,21 @@
-
-use std::boxed::Box;
 use crate::FetchInfo;
+use std::boxed::Box;
 
-use serde::Serialize;
-use serde_json::json;
-use actix_web::HttpResponse;
 use actix_web::body::BoxBody;
 use actix_web::http::StatusCode;
+use actix_web::HttpResponse;
 use actix_web::ResponseError;
+use serde::Serialize;
+use serde_json::json;
 
 use async_process::ExitStatus;
 
-use crate::log;
+use dbc_rust_modules::log as dbc_log;
 
 #[allow(dead_code)]
 pub enum ImageBuildError {
     NotFound,
-    Other
+    Other,
 }
 
 #[derive(Debug)]
@@ -51,7 +50,7 @@ pub enum DockerErrorCode {
     #[serde(rename = "NAME_INVALID")]
     NameInvalid,
     #[serde(rename = "SNAFU")]
-    Snafu
+    Snafu,
 }
 
 #[derive(Debug, Serialize)]
@@ -64,7 +63,6 @@ pub struct DockerError {
 pub trait DockerErrorContext {
     fn manifest_context(self, info: &FetchInfo) -> DockerError;
     fn blob_context(self, info: &FetchInfo) -> DockerError;
-
 }
 
 pub trait DockerErrorDetails {
@@ -105,12 +103,23 @@ impl DockerErrorDetails for RepoError {
                     let msg = e.message();
                     format!("git2 error: {code:?}. Message: {msg}")
                 }
+            },
+            RepoError::IndexFile(_) => {
+                "failed to read repository index file: /default.nix".to_string()
             }
-            RepoError::IndexFile(_) => "failed to read repository index file: /default.nix".to_string(),
-            RepoError::IndexAttributeNotFound => format!("attribute: {} not found in repository index: /default.nix", &info.name),
-            RepoError::ImageNotFound => format!("image with name: {} and reference: {} not found", &info.reference, &info.name),
-            RepoError::BlobNotFound => format!("blob: {} not found for image: {}", &info.reference, &info.name),
-            _ => "unknown error".to_string()
+            RepoError::IndexAttributeNotFound => format!(
+                "attribute: {} not found in repository index: /default.nix",
+                &info.name
+            ),
+            RepoError::ImageNotFound => format!(
+                "image with name: {} and reference: {} not found",
+                &info.reference, &info.name
+            ),
+            RepoError::BlobNotFound => format!(
+                "blob: {} not found for image: {}",
+                &info.reference, &info.name
+            ),
+            _ => "unknown error".to_string(),
         }
     }
     fn docker_details(&self) -> String {
@@ -118,8 +127,10 @@ impl DockerErrorDetails for RepoError {
     }
 }
 
-
-impl<T> DockerErrorContext for T where T: DockerErrorDetails {
+impl<T> DockerErrorContext for T
+where
+    T: DockerErrorDetails,
+{
     fn manifest_context(self, info: &FetchInfo) -> DockerError {
         self.to_docker_error(info, DockerErrorCode::ManifestUnknown)
     }
@@ -135,29 +146,29 @@ impl DockerError {
         DockerError {
             code: DockerErrorCode::NameUnknown,
             details: message.clone(),
-            message
+            message,
         }
     }
     pub fn blob_unknown(digest: &str) -> Self {
         DockerError {
             code: DockerErrorCode::BlobUnknown,
             message: "blob unknown to registry".to_string(),
-            details: (json!({ "digest": digest })).to_string()
+            details: (json!({ "digest": digest })).to_string(),
         }
     }
     pub fn snafu(text: &str) -> Self {
         DockerError {
             code: DockerErrorCode::Snafu,
             message: text.to_string(),
-            details: text.to_string()
+            details: text.to_string(),
         }
     }
     pub fn unknown<E: std::fmt::Debug>(text: &str, err: E) -> Self {
-        log::error(text, &err);
+        dbc_log::error(text, &err);
         DockerError {
             code: DockerErrorCode::Snafu,
             message: text.to_string(),
-            details: text.to_string()
+            details: text.to_string(),
         }
     }
     #[cfg(feature = "mysql")]
@@ -166,7 +177,7 @@ impl DockerError {
         DockerError {
             code: DockerErrorCode::NameInvalid,
             details: message.clone(),
-            message
+            message,
         }
     }
 }
@@ -183,7 +194,7 @@ impl ResponseError for DockerError {
     }
 
     fn error_response(&self) -> HttpResponse<BoxBody> {
-        let errors = vec!(self);
+        let errors = vec![self];
         let errors = json!({ "errors": errors });
         HttpResponse::NotFound()
             .append_header(("Docker-Distribution-API-Version", "registry/2.0"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ use regex::Regex;
 use tempfile::NamedTempFile;
 use std::ffi::OsStr;
 
-use dbc_rust_modules::log;
+use dbc_rust_modules::log as dbc_log;
 
 use serde::Deserialize;
 use lazy_static::lazy_static;
@@ -165,7 +165,7 @@ impl ManifestDelivery {
         match self {
             ManifestDelivery::Repo(_) | ManifestDelivery::Path(_) => {
                 let fq: PathBuf = serve_root.join(INDEX_FILE_PATH.get().unwrap().as_ref().map(|i| i.to_str().unwrap()).unwrap());
-                log::data("looking for indexfile at", &fq);
+                dbc_log::data("looking for indexfile at", &fq);
 
                 let mut cmd = Command::new("nix-instantiate");
                 let child = cmd
@@ -285,13 +285,13 @@ impl BlobDelivery {
                     Ok(_) => {}
                     Err(e) => {
                         if e.kind() != ErrorKind::AlreadyExists {
-                            log::error(&format!("error caching: {}", &info.name), &e);
+                            dbc_log::error(&format!("error caching: {}", &info.name), &e);
                         }
                     }
                 }
                 if is_gc_rootable && *ADD_NIX_GCROOTS.get().unwrap() {
                     nix_add_root(&cache_path, &info.path).await.or_else(|e| {
-                        log::error(&format!("error caching: {}", &info.name), &e);
+                        dbc_log::error(&format!("error caching: {}", &info.name), &e);
                         Err(e)
                     }).unwrap();
                 }
@@ -415,7 +415,7 @@ const APP_NAME: &str = env!("CARGO_PKG_NAME");
 
 fn main() {
 
-    log::init(APP_NAME.to_string()).unwrap();
+    dbc_log::init(APP_NAME.to_string()).unwrap();
 
     let args = clap::App::new("wharfix")
     .arg(clap::Arg::with_name("path")
@@ -537,7 +537,7 @@ fn main() {
             .or_else(|e| Err(MainError::ListenBind(e)))
 
     }() {
-        log::error("startup error", &e);
+        dbc_log::error("startup error", &e);
     }
 }
 
@@ -548,7 +548,7 @@ fn db_connect(creds_file: PathBuf) -> Pool {
 
 #[actix_rt::main]
 async fn listen(listen_address: String, listen_port: u16) -> std::io::Result<()>{
-    log::info(&format!("start listening on port: {}", listen_port));
+    dbc_log::info(&format!("start listening on port: {}", listen_port));
 
     let manifest_url = "/v2/{name}/manifests/{reference}";
     let blob_url = "/v2/{name}/blobs/{reference}";
@@ -556,9 +556,9 @@ async fn listen(listen_address: String, listen_port: u16) -> std::io::Result<()>
     HttpServer::new(move || {
         App::new()
             .wrap_fn(|req, srv| {
-                log::new_session();
+                dbc_log::new_session();
                 let host = req.headers().get("HOST").and_then(|hv| hv.to_str().ok()).unwrap_or("");
-                log::data("request", &json!({ "endpoint": format!("{}", req.path()), "host": host }));
+                dbc_log::data("request", &json!({ "endpoint": format!("{}", req.path()), "host": host }));
                 srv.call(req)
             })
             .wrap(middleware::Compress::default())
@@ -652,7 +652,7 @@ async fn manifest(registry: Registry, info: web::Path<FetchInfo>) -> Result<Whar
                 true => path.join("manifest.json"),
                 false => path.clone()
             };
-            log::info(&format!("serving manifest from path: {:?}", &fq));
+            dbc_log::info(&format!("serving manifest from path: {:?}", &fq));
             match fs::read_to_string(&fq) {
                 Ok(manifest_str) => {
                     registry.blob_discovery(&path.join("blobs")).await;
@@ -669,7 +669,7 @@ async fn manifest(registry: Registry, info: web::Path<FetchInfo>) -> Result<Whar
                     Ok(WharfixManifest::new(manifest_str, fq))
                 },
                 Err(e) => {
-                    log::error(&format!("failed to read manifest for image: {name}, {reference}", name=info.name, reference=info.reference), &e);
+                    dbc_log::error(&format!("failed to read manifest for image: {name}, {reference}", name=info.name, reference=info.reference), &e);
                     Err(e.manifest_context(&info))
                 }
             }
@@ -720,7 +720,7 @@ async fn blob(registry: Registry, info: web::Path<FetchInfo>) -> Result<WharfixB
             })
         },
         Err(e) => {
-            log::error(&format!("failed to read blob: {digest}", digest=&info.reference), &e);
+            dbc_log::error(&format!("failed to read blob: {digest}", digest=&info.reference), &e);
             Err(e)
         }
     }
@@ -745,7 +745,7 @@ fn repo_open(name: &str, url: &String) -> Result<Repository, RepoError> {
     Ok(if clone_target.exists() {
         Repository::open_bare(&clone_target).or_else(|e| Err(RepoError::Git(e)))
     } else {
-        log::info(&format!("registry, url: {}, {} - does not exist, initing at: {:?}", &name, &url, &clone_target));
+        dbc_log::info(&format!("registry, url: {}, {} - does not exist, initing at: {:?}", &name, &url, &clone_target));
         let mut init_opts = RepositoryInitOptions::new();
         init_opts.bare(true);
         init_opts.no_reinit(true);

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,17 @@ use regex::Regex;
 use tempfile::NamedTempFile;
 use std::ffi::OsStr;
 
+#[cfg(not(feature = "oldlogs"))]
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+
+#[cfg(not(feature = "oldlogs"))]
+extern crate log;
+
+#[cfg(not(feature = "oldlogs"))]
+extern crate pretty_env_logger;
+
+#[cfg(feature = "oldlogs")]
 use dbc_rust_modules::log as dbc_log;
 
 use serde::Deserialize;
@@ -165,6 +176,9 @@ impl ManifestDelivery {
         match self {
             ManifestDelivery::Repo(_) | ManifestDelivery::Path(_) => {
                 let fq: PathBuf = serve_root.join(INDEX_FILE_PATH.get().unwrap().as_ref().map(|i| i.to_str().unwrap()).unwrap());
+                #[cfg(not(feature = "oldlogs"))]
+                info!("looking for indexfile at {:?}", &fq);
+                #[cfg(feature = "oldlogs")]
                 dbc_log::data("looking for indexfile at", &fq);
 
                 let mut cmd = Command::new("nix-instantiate");
@@ -285,12 +299,18 @@ impl BlobDelivery {
                     Ok(_) => {}
                     Err(e) => {
                         if e.kind() != ErrorKind::AlreadyExists {
+                            #[cfg(not(feature = "oldlogs"))]
+                            error!("error caching: {}, {:#?}", &info.name, &e);
+                            #[cfg(feature = "oldlogs")]
                             dbc_log::error(&format!("error caching: {}", &info.name), &e);
                         }
                     }
                 }
                 if is_gc_rootable && *ADD_NIX_GCROOTS.get().unwrap() {
                     nix_add_root(&cache_path, &info.path).await.or_else(|e| {
+                        #[cfg(not(feature = "oldlogs"))]
+                        error!("error caching: {}, {:#?}", &info.name, &e);
+                        #[cfg(feature = "oldlogs")]
                         dbc_log::error(&format!("error caching: {}", &info.name), &e);
                         Err(e)
                     }).unwrap();
@@ -414,7 +434,10 @@ impl FromRequest for Registry {
 const APP_NAME: &str = env!("CARGO_PKG_NAME");
 
 fn main() {
+    #[cfg(not(feature = "oldlogs"))]
+    pretty_env_logger::init();
 
+    #[cfg(feature = "oldlogs")]
     dbc_log::init(APP_NAME.to_string()).unwrap();
 
     let args = clap::App::new("wharfix")
@@ -537,6 +560,9 @@ fn main() {
             .or_else(|e| Err(MainError::ListenBind(e)))
 
     }() {
+        #[cfg(not(feature = "oldlogs"))]
+        error!("startup error: {:#?}", &e);
+        #[cfg(feature = "oldlogs")]
         dbc_log::error("startup error", &e);
     }
 }
@@ -548,6 +574,10 @@ fn db_connect(creds_file: PathBuf) -> Pool {
 
 #[actix_rt::main]
 async fn listen(listen_address: String, listen_port: u16) -> std::io::Result<()>{
+    #[cfg(not(feature = "oldlogs"))]
+    info!("start listening on port: {}", listen_port);
+
+    #[cfg(feature = "oldlogs")]
     dbc_log::info(&format!("start listening on port: {}", listen_port));
 
     let manifest_url = "/v2/{name}/manifests/{reference}";
@@ -556,8 +586,14 @@ async fn listen(listen_address: String, listen_port: u16) -> std::io::Result<()>
     HttpServer::new(move || {
         App::new()
             .wrap_fn(|req, srv| {
+                #[cfg(feature = "oldlogs")]
                 dbc_log::new_session();
                 let host = req.headers().get("HOST").and_then(|hv| hv.to_str().ok()).unwrap_or("");
+
+                #[cfg(not(feature = "oldlogs"))]
+                info!("request: {}", &json!({ "endpoint": format!("{}", req.path()), "host": host }));
+
+                #[cfg(feature = "oldlogs")]
                 dbc_log::data("request", &json!({ "endpoint": format!("{}", req.path()), "host": host }));
                 srv.call(req)
             })
@@ -652,6 +688,10 @@ async fn manifest(registry: Registry, info: web::Path<FetchInfo>) -> Result<Whar
                 true => path.join("manifest.json"),
                 false => path.clone()
             };
+            #[cfg(not(feature = "oldlogs"))]
+            info!("serving manifest from path: {:?}", &fq);
+
+            #[cfg(feature = "oldlogs")]
             dbc_log::info(&format!("serving manifest from path: {:?}", &fq));
             match fs::read_to_string(&fq) {
                 Ok(manifest_str) => {
@@ -669,6 +709,10 @@ async fn manifest(registry: Registry, info: web::Path<FetchInfo>) -> Result<Whar
                     Ok(WharfixManifest::new(manifest_str, fq))
                 },
                 Err(e) => {
+                    #[cfg(not(feature = "oldlogs"))]
+                    error!("failed to read manifest for image: {name}, {reference}", name=info.name, reference=info.reference);
+
+                    #[cfg(feature = "oldlogs")]
                     dbc_log::error(&format!("failed to read manifest for image: {name}, {reference}", name=info.name, reference=info.reference), &e);
                     Err(e.manifest_context(&info))
                 }
@@ -720,6 +764,10 @@ async fn blob(registry: Registry, info: web::Path<FetchInfo>) -> Result<WharfixB
             })
         },
         Err(e) => {
+            #[cfg(not(feature = "oldlogs"))]
+            error!("failed to read blob: {digest}", digest=&info.reference);
+
+            #[cfg(feature = "oldlogs")]
             dbc_log::error(&format!("failed to read blob: {digest}", digest=&info.reference), &e);
             Err(e)
         }
@@ -745,7 +793,12 @@ fn repo_open(name: &str, url: &String) -> Result<Repository, RepoError> {
     Ok(if clone_target.exists() {
         Repository::open_bare(&clone_target).or_else(|e| Err(RepoError::Git(e)))
     } else {
+        #[cfg(not(feature = "oldlogs"))]
+        info!("registry, url: {}, {} - does not have an active clone, cloning into: {:?}", &name, &url, &clone_target);
+
+        #[cfg(feature = "oldlogs")]
         dbc_log::info(&format!("registry, url: {}, {} - does not exist, initing at: {:?}", &name, &url, &clone_target));
+
         let mut init_opts = RepositoryInitOptions::new();
         init_opts.bare(true);
         init_opts.no_reinit(true);


### PR DESCRIPTION
NOTE: This is stacked on #100.

- **build(cargo): add `log` and `pretty_env_log` to dependencies**
- **feat: add "idiomatic" rust logging**

This introduces the `oldlog` feature to preserve the old logging style, but
default to using the more *idiomatic* logging macros with `pretty_env_logger`
(which should be easy to replace with something else).

This is partially to make the output more readable, and I was informed that the
logging format is kinda an idea that never took off.
