### PR TITLE
ci: build -> flake check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: "Build"
+name: "Check"
 on:
 - push
 - workflow_dispatch
@@ -7,4 +7,4 @@ jobs:
     runs-on: self-hosted
     steps:
     - uses: actions/checkout@v2.3.4
-    - run: nix --experimental-features "nix-command flakes" build
+    - run: nix --experimental-features "nix-command flakes" flake check


### PR DESCRIPTION
Change the default Github CI action to flake check. The check implies a build of wharfix, so I hope it's ok we don't have an explicit nix-build step? Let me know what you think.