### PR TITLE
fix: clap upgrade broke mysql feature

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,17 +1,16 @@
 use clap::{arg, command, crate_authors, Command};
 
 pub fn build_cli() -> Command {
-    command!()
+    let cmd = command!()
         .author(crate_authors!("\n"))
         .arg(
             arg!(--path <PATH> "Path to directory of static docker image specs.")
-                .required_unless_present_any(["repo", "dbconnfile", "derivationoutput"]),
+                .required_unless_present_any(["repo", "derivationoutput"]),
         )
         .arg(
             arg!(--repo <REPO> "URL to git repository.")
                 .required_unless_present_any([
                 "path",
-                "dbconnfile",
                 "derivationoutput",
             ]),
         )
@@ -21,7 +20,6 @@ pub fn build_cli() -> Command {
                 .required(false)
                 .required_unless_present_any([
                     "path",
-                    "dbconnfile",
                     "repo",
                 ]),
         )
@@ -72,13 +70,17 @@ pub fn build_cli() -> Command {
             arg!(--port <PORT> "Listen port to open on <address>.")
                 .required(true)
                 .default_value("8088")
-        )
-        .arg(
+        );
+
+        #[cfg(feature = "mysql")]
+        let cmd = cmd.arg(
             arg!(--dbconnfile <DBCONNFILE> "Path to file from which to read db connection details.")
                 .required_unless_present_any([
                     "path",
                     "repo",
                     "derivationoutput",
                 ]),
-        )
+        );
+        #[cfg(not(feature = "oldlogs"))]
+        cmd
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -441,15 +441,6 @@ fn main() {
     #[cfg(feature = "oldlogs")]
     dbc_log::init(APP_NAME.to_string()).unwrap();
 
-
-
-    #[cfg(feature = "mysql")]
-    let args = args.arg(clap::Arg::with_name("dbconnfile")
-        .long("dbconnfile")
-        .help("Path to file from which to read db connection details")
-        .takes_value(true)
-        .required_unless_one(&["path", "repo", "derivationoutput"]));
-
     if let Err(e) = || -> Result<(), MainError> {
 
         let m = cli::build_cli().get_matches();
@@ -471,7 +462,7 @@ fn main() {
                .or(Err(MainError::ArgParse("cmdline arg 'path' doesn't look like an actual path")))?),
            m if m.contains_id("repo") => ServeType::Repo(m.get_one::<String>("repo").unwrap().to_string()),
            #[cfg(feature = "mysql")]
-           m if m.is_present("dbconnfile") => ServeType::Database(db_connect(PathBuf::from_str(m.value_of("dbconnfile").unwrap()).unwrap())),
+           m if m.contains_id("dbconnfile") => ServeType::Database(db_connect(PathBuf::from_str(m.get_one::<String>("dbconnfile").unwrap()).unwrap())),
            m if m.contains_id("derivationoutput") => ServeType::Derivation(m.get_one::<String>("derivationoutput").unwrap().to_string()),
            _ => panic!("clap should ensure this never happens")
         });


### PR DESCRIPTION
Drop mutual exclusive flag checks for --dbconnfile, since clap 4 apparently actually have runtime checks for whether an arg constraint is spelled correctly.

I prefer (subjectively) having --dbconnfile not appear as a possible arg when wharfix is not compiled with "mysql"-support, over having correct mutual exclusion checks.