### PR TITLE
fixup: macro copy/paste mistake

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,6 +81,5 @@ pub fn build_cli() -> Command {
                     "derivationoutput",
                 ]),
         );
-        #[cfg(not(feature = "oldlogs"))]
         cmd
 }


### PR DESCRIPTION
lol... macro copy-paste mistake, sorry. Now `oldlogs` build again.
The CI should really build all permutations of features; compile at least.