### PR TITLE
fixup: required arguments when using the mysql feature

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,12 +5,19 @@ pub fn build_cli() -> Command {
         .author(crate_authors!("\n"))
         .arg(
             arg!(--path <PATH> "Path to directory of static docker image specs.")
-                .required_unless_present_any(["repo", "derivationoutput"]),
+                .required_unless_present_any([
+                    "repo",
+                    #[cfg(feature = "mysql")]
+                    "dbconnfile",
+                    "derivationoutput",
+                ]),
         )
         .arg(
             arg!(--repo <REPO> "URL to git repository.")
                 .required_unless_present_any([
                 "path",
+                #[cfg(feature = "mysql")]
+                "dbconnfile",
                 "derivationoutput",
             ]),
         )
@@ -20,6 +27,8 @@ pub fn build_cli() -> Command {
                 .required(false)
                 .required_unless_present_any([
                     "path",
+                    #[cfg(feature = "mysql")]
+                    "dbconnfile",
                     "repo",
                 ]),
         )


### PR DESCRIPTION
turns out we _have_ to do this the ugly way (as decribed https://github.com/wharfix/wharfix/pull/109#issuecomment-2012445332), otherwise suddenly path/repo is required even when using "dbconnfile".

it's not _that_ bad when doing it this way, unless all the feature-guard macros hurt eyes too much.

sorry for not testing this earlier, I really should write an integration test for the mysql feature.