### PR TITLE
ci: build all features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: "tests feature combinations"
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+jobs:
+  build:
+    name: cargo build/test ${{ matrix.features }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features: ["", "-F mysql", "-F oldlogs", "-F mysql -F oldlogs"]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo build ${{ matrix.features }}
+    - run: cargo test ${{ matrix.features }}


### PR DESCRIPTION
This tests all feature combinations we currently support (it's not fancy enough to figure out features itself). It is however fancy enough to cache dependency artifacts from cargo.

Also, this is not on the self-hosted runner because that requires changing that runner to add cargo dependencies, and also because it only seems to be able to run a single check at a time. 

By using github runners instead, we get waste their cycles for free, and we get to do so in parallel :D 

Closes: #112 