### PR TITLE
fix dependencies to major versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,30 +7,30 @@ edition = "2021"
 rust-version = "1.70.0"
 
 [dependencies]
-clap = { version = "=4.4", features = ["cargo"] }
-serde = { version = "1", features = [ "derive" ] }
-serde_json = "1"
-erased-serde = "0"
-actix-web = "4"
 actix-rt = "2"
-tokio = { version = "1", features = [ "full" ] }
+actix-web = "4"
+async-process = "1"
+async-stream = "0.3.5"
+clap = { version = "=4.4", features = ["cargo"] }
+dbc-rust-modules = { git = "https://github.com/dbcdk/rust-modules", branch = "main", features = ["log"], default-features = false }
+erased-serde = "0"
 futures = "0"
-uuid = { version = "0", features = ["v4"] }
+get_chunk = { version = "1.2.0", features = ["stream", "size_format"] }
+git2 = "0"
 lazy_static = "1"
 linereader = "0"
-walkdir = "2"
-git2 = "0"
+log = "0.4.20"
+mysql = { version = "24", optional = true }
+pretty_env_logger = "0.5.0"
+regex = "1"
+serde = { version = "1", features = [ "derive" ] }
+serde_json = "1"
+sha2 = "0"
 tempdir = "0"
 tempfile = "3"
-regex = "1"
-mysql = { version = "24", optional = true }
-sha2 = "0"
-dbc-rust-modules = { git = "https://github.com/dbcdk/rust-modules", branch = "main", features = ["log"], default-features = false }
-async-process = "1"
-get_chunk = { version = "1.2.0", features = ["stream", "size_format"] }
-async-stream = "0.3.5"
-log = "0.4.20"
-pretty_env_logger = "0.5.0"
+tokio = { version = "1", features = [ "full" ] }
+uuid = { version = "0", features = ["v4"] }
+walkdir = "2"
 
 [features]
 mysql = ["dep:mysql"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,23 +13,23 @@ async-process = "1"
 async-stream = "0.3.5"
 clap = { version = "=4.4", features = ["cargo"] }
 dbc-rust-modules = { git = "https://github.com/dbcdk/rust-modules", branch = "main", features = ["log"], default-features = false }
-erased-serde = "0"
-futures = "0"
+erased-serde = "0.4"
+futures = "0.3"
 get_chunk = { version = "1.2.0", features = ["stream", "size_format"] }
-git2 = "0"
+git2 = "0.19"
 lazy_static = "1"
-linereader = "0"
+linereader = "0.4"
 log = "0.4.20"
 mysql = { version = "24", optional = true }
 pretty_env_logger = "0.5.0"
 regex = "1"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
-sha2 = "0"
-tempdir = "0"
+sha2 = "0.10"
+tempdir = "0.3"
 tempfile = "3"
 tokio = { version = "1", features = [ "full" ] }
-uuid = { version = "0", features = ["v4"] }
+uuid = { version = "0.8", features = ["v4"] }
 walkdir = "2"
 
 [features]


### PR DESCRIPTION
Currently, several versions are locked on `0`. Because of how semver
works, this means that of these dependencies are allow to freely be
upgraded with breaking changes. Essentially, it's equivalent to setting
`*`, only as long as it doesn't go to a "one dot" release.

Most of the cargo ecosystem is pre one dot, and will be so forever, so
this is extremely brittle.

wharfix v0.1.0 (/home/ces/org/src/dbc/wharfix)
├── actix-rt v2.10.0
├── actix-web v4.9.0
├── async-process v1.8.1
├── async-stream v0.3.5
├── clap v4.4.18
├── dbc-rust-modules v0.1.0 (https://github.com/dbcdk/rust-modules?branch=main#ab38efd1)
├── erased-serde v0.4.5
├── futures v0.3.30
├── get_chunk v1.2.2
├── git2 v0.19.0
├── lazy_static v1.5.0
├── linereader v0.4.0
├── log v0.4.22
├── pretty_env_logger v0.5.0
├── regex v1.10.6
├── serde v1.0.210
├── serde_json v1.0.128
├── sha2 v0.10.8
├── tempdir v0.3.7
├── tempfile v3.12.0
├── tokio v1.40.0
├── uuid v0.8.2
└── walkdir v2.5.0

This also sorts the dependencies alphanumerically.

Signed-off-by: Christina Sørensen <christina@cafkafk.com>
