### PR TITLE
shutdown on fd exhaustion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libgit2-sys"
@@ -3239,6 +3239,7 @@ dependencies = [
  "get_chunk",
  "git2",
  "lazy_static",
+ "libc",
  "linereader",
  "log",
  "mysql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3"
 get_chunk = { version = "1.2", features = ["stream", "size_format"] }
 git2 = "0.19"
 lazy_static = "1"
+libc = "0.2.169"
 linereader = "0.4"
 log = "0.4"
 mysql = { version = "24", optional = true }


### PR DESCRIPTION
experienced this fd leak: 
```
ERROR actix_server::accept > error accepting connection: Too many open files
```
wharfix remained in a bad state until the process died. 

not really sure how to fix this properly. so here's a very crude fix, meant mostly as a conversation starter.

I'm open to implementing whatever solution if there's any ideas. if tokio doesn't call setrlimit on EMFILE, maybe it's just a matter of raising soft_limit