### PR TITLE
fix nix-instantiate on deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ by setting the `--index-file-path <indexfilepath>` option.
 
 <!-- Clarify this -->
 `--index-file-is-buildable` can be used to set if the provided index-file is a
-valid nix entrypoint by itself (i.e. don't use internal drv-wrapper).
+
+`--index-file-is-attrset` can be used if the index does not take arguments but
+instead is a bare attrset of images
 
 ##### Authenticating over SSH
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,12 @@ pub fn build_cli() -> Command {
                 .required(false)
         )
         .arg(
+            arg!(indexfileisattrset: "Set if the provided index-file is not a function but a raw attrset of images")
+                .action(clap::ArgAction::SetTrue)
+                .long("index-file-is-attrset")
+                .required(false)
+        )
+        .arg(
             arg!(sshprivatekey:<SSHPRIVATEKEY> "Path to optional ssh private key file.")
                 .long("ssh-private-key")
                 .required(false)

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,10 @@ impl ManifestDelivery {
                 );
                 log::info!("looking for indexfile at {:?}", &fq);
 
+                let name = &info.name;
+                let fqs = &fq
+                    .to_str()
+                    .expect("Failed turning fqdn into string in ManifestDelivery.index");
                 let import_argset = if *INDEX_FILE_IS_ATTRSET
                     .get()
                     .expect("Failed unlocking INDEX_FILE_IS_ATTRSET in ManifestDelivery.index")
@@ -193,6 +197,7 @@ impl ManifestDelivery {
                     // isFunction like nix-build does
                     " {}"
                 };
+
                 let mut cmd = Command::new("nix-instantiate");
                 let child = cmd
                     // allow registering paths, maybe we need inputs to generate attributes
@@ -200,10 +205,7 @@ impl ManifestDelivery {
                     .arg("--eval")
                     .arg("-E")
                     .arg(format!(
-                        "builtins.hasAttr \"{}\" (import {}{import_argset})",
-                        &info.name,
-                        &fq.to_str()
-                            .expect("Failed turning fqdn into string in ManifestDelivery.index"),
+                        "builtins.hasAttr \"{name}\" (import {fqs}{import_argset})"
                     ))
                     .stdout(Stdio::piped())
                     .spawn()

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ use std::sync::OnceLock;
 
 static ADD_NIX_GCROOTS: OnceLock<bool> = OnceLock::new();
 static INDEX_FILE_IS_BUILDABLE: OnceLock<bool> = OnceLock::new();
+static INDEX_FILE_IS_ATTRSET: OnceLock<bool> = OnceLock::new();
 static SERVE_TYPE: OnceLock<Option<ServeType>> = OnceLock::new();
 static TARGET_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
 static BLOB_CACHE_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
@@ -181,16 +182,28 @@ impl ManifestDelivery {
                 );
                 log::info!("looking for indexfile at {:?}", &fq);
 
+                let import_argset = if *INDEX_FILE_IS_ATTRSET
+                    .get()
+                    .expect("Failed unlocking INDEX_FILE_IS_ATTRSET in ManifestDelivery.index")
+                {
+                    ""
+                } else {
+                    // The empty (nix) argset, provided as an argument for
+                    // nix-instantiation eval which will _not_ auto-detect
+                    // isFunction like nix-build does
+                    " {}"
+                };
                 let mut cmd = Command::new("nix-instantiate");
                 let child = cmd
+                    // allow registering paths, maybe we need inputs to generate attributes
+                    .arg("--read-write-mode")
                     .arg("--eval")
                     .arg("-E")
                     .arg(format!(
-                        "builtins.hasAttr \"{}\" (import {} {})",
+                        "builtins.hasAttr \"{}\" (import {}{import_argset})",
                         &info.name,
                         &fq.to_str()
                             .expect("Failed turning fqdn into string in ManifestDelivery.index"),
-                        "{}"
                     ))
                     .stdout(Stdio::piped())
                     .spawn()
@@ -627,6 +640,7 @@ fn main() {
 
         ADD_NIX_GCROOTS.get_or_init(|| m.get_flag("addnixgcroots"));
         INDEX_FILE_IS_BUILDABLE.get_or_init(|| m.get_flag("indexfileisbuildable"));
+        INDEX_FILE_IS_ATTRSET.get_or_init(|| m.get_flag("indexfileisattrset"));
         SERVE_TYPE.get_or_init(|| serve_type);
         TARGET_DIR.get_or_init(|| {
             Some(fs::canonicalize(target_dir).expect("Failed to canonicalize target_dir in main"))


### PR DESCRIPTION
Two main changes,

- allow nix-instantiate to realise paths (useful for eg. realising
  inputs from flake-compat if the index is really from a thinly-wrapped
  flake)
- Allow the index to not be a function, again useful for more flakeful
  setups that don't take the usual (old-nix style) `{ pkgs ? ... }:`.
  This is necessary because unlike nix-build, nix-instantiate --eval
  --expr will not prefill the empty argset.